### PR TITLE
"$value" parameter is now taken into account just after post parameter

### DIFF
--- a/design/standard/templates/content/datatype/collect/owenhancedselection.tpl
+++ b/design/standard/templates/content/datatype/collect/owenhancedselection.tpl
@@ -3,7 +3,9 @@
 
 {if ezhttp_hasvariable( concat('ContentObjectAttribute_owenhancedselection_selection_',$attribute.id) )}
     {def $post_value = ezhttp( concat('ContentObjectAttribute_owenhancedselection_selection_',$attribute.id) )
-         $selected_id_array = cond(is_null($post_value)|not(), $post_value , is_set($value), $value, $content.identifiers)}
+         $selected_id_array = array(cond(is_null($post_value)|not(), $post_value , $content.identifiers))}
+{elseif is_set($value)}
+    {def $selected_id_array = array($value)}
 {else}
     {def $selected_id_array = array()}
 {/if}


### PR DESCRIPTION
This fixes the support of "$value" parameter passed to collect tpl in order to select one specific option.
Previously, it did not work because "$value" parameter was handled only if a post parameter was passed.

Do you wanna merge ?
